### PR TITLE
Featured Content Changes

### DIFF
--- a/admin/class-jacobin-core-admin.php
+++ b/admin/class-jacobin-core-admin.php
@@ -65,6 +65,11 @@ class Jacobin_Core_Admin {
 			add_action( 'admin_menu', array( $this, 'add_options_page' ) );
 		}
 
+		/**
+		 * Add JS to admin head for ACF
+		 */
+		add_action( 'acf/input/admin_head', array( $this, 'admin_head' ) );
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 
 		// Modify custom post args
@@ -110,6 +115,35 @@ class Jacobin_Core_Admin {
 	 */
 	public function get_setting_name() {
 		return $this->setting_name;
+	}
+
+	/**
+	 * Add Script to ACF Admin Head
+	 *
+	 * @since 0.2.7
+	 *
+	 * @link https://www.advancedcustomfields.com/resources/acfinputadmin_head/
+	 *
+	 * @return void
+	 */
+	public function admin_head() {
+		?>
+		 <script type="text/javascript">
+		 (function($) {
+
+				 $(document).ready(function(){
+
+						 $('.acf-field-postexpert .acf-input').append( $('#postexcerpt #excerpt') );
+						 $('#postexcerpt').remove();
+
+						 $('#coauthorsdiv').insertAfter( '#submitdiv' );
+
+				 });
+
+		 })(jQuery);
+		 </script>
+		 <style type="text/css"></style>
+	 <?php
 	}
 
 	/**

--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -255,6 +255,23 @@
        			'readonly' => 0,
        			'disabled' => 0,
        		),
+          array (
+      			'key' => 'field_postexpert',
+      			'label' => __( 'Excerpt', 'jacobin-core' ),
+      			'name' => '',
+      			'type' => 'message',
+      			'instructions' => '',
+      			'required' => 0,
+      			'conditional_logic' => 0,
+      			'wrapper' => array (
+      				'width' => '',
+      				'class' => '',
+      				'id' => '',
+      			),
+      			'message' => '',
+      			'new_lines' => 'wpautop',
+      			'esc_html' => 0,
+      		),
        		array (
        			'key' => 'field_57dc2f429f3be',
        			'label' => __( 'Translator', 'jacobin-core' ),

--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -28,7 +28,103 @@
 
          if( function_exists( 'register_field_group' ) ) {
              $this->register_field_groups();
+             $this->register_settings_fields();
          }
+     }
+
+     /**
+      * Register Clone Fields
+      * Register fields that will be used as clone-able fields
+      *
+      * @since 0.2.7
+      *
+      * @depends on ACF 5.5+
+      * @link https://www.advancedcustomfields.com/resources/clone/
+      *
+      * @return void
+      */
+     public function register_clone_fields() {
+       acf_add_local_field_group(array (
+        	'key' => 'group_58b9cbbf18c46',
+        	'title' => 'Featured Posts',
+        	'fields' => array (
+        		array (
+        			'key' => 'field_58b9cbd0ce677',
+        			'label' => 'Featured Posts (5 max)',
+        			'name' => 'featured_posts',
+        			'type' => 'relationship',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'post_type' => array (
+        				0 => 'post',
+        			),
+        			'taxonomy' => array (
+        			),
+        			'filters' => array (
+        				0 => 'search',
+        				1 => 'taxonomy',
+        			),
+        			'elements' => array (
+        				0 => 'featured_image',
+        			),
+        			'min' => 1,
+        			'max' => 5,
+        			'return_format' => 'id',
+        		),
+        		array (
+        			'key' => 'field_58b9ce520c8e2',
+        			'label' => 'Featured Post (Single)',
+        			'name' => 'featured_post',
+        			'type' => 'relationship',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'post_type' => array (
+        				0 => 'post',
+        			),
+        			'taxonomy' => array (
+        			),
+        			'filters' => array (
+        				0 => 'search',
+        				1 => 'taxonomy',
+        			),
+        			'elements' => array (
+        				0 => 'featured_image',
+        			),
+        			'min' => 1,
+        			'max' => 1,
+        			'return_format' => 'id',
+        		),
+        	),
+        	'location' => array (
+        		array (
+        			array (
+        				'param' => 'post_type',
+        				'operator' => '==',
+        				'value' => 'post',
+        			),
+        		),
+        	),
+        	'menu_order' => 0,
+        	'position' => 'normal',
+        	'style' => 'default',
+        	'label_placement' => 'top',
+        	'instruction_placement' => 'label',
+        	'hide_on_screen' => '',
+        	'active' => 0,
+        	'description' => '',
+        ));
      }
 
      /**
@@ -1381,7 +1477,7 @@
        /**
         * Chart Custom Post Type Fields
         */
-       acf_add_local_field_group(array (
+       acf_add_local_field_group( array (
        	'key' => 'group_579a3a3ac715e',
        	'title' => __( 'Charts', 'jacobin-core' ),
        	'fields' => array (
@@ -1583,7 +1679,7 @@
        /**
         * Timeline Post Type Custom Fields
         */
-       acf_add_local_field_group(array (
+       acf_add_local_field_group( array (
        	'key' => 'group_57991c7567f52',
        	'title' => __( 'Timeline', 'jacobin-core' ),
        	'fields' => array (
@@ -1696,119 +1792,175 @@
        	'local' => 'php',
        ));
 
+     }
+
+     /**
+      * Register Settings Fields
+      *
+      * @uses acf_add_local_field_group()
+      *
+      * @link https://www.advancedcustomfields.com/resources/options-page/
+      *
+      * @return void
+      */
+     public function register_settings_fields() {
        /**
         * Featured Content Options Page Fields
         */
-       acf_add_local_field_group(array (
-       	'key' => 'group_5848fe5fa5798',
-       	'title' => __( 'Featured Content', 'jacobin-core' ),
-       	'fields' => array (
-       		array (
-       			'key' => 'field_5849e2a4fefc7',
-       			'label' => __( 'Home Page Feature', 'jacobin-core' ),
-       			'name' => 'home_feature',
-       			'type' => 'relationship',
-       			'instructions' => '',
-       			'required' => 0,
-       			'conditional_logic' => 0,
-       			'wrapper' => array (
-       				'width' => '',
-       				'class' => '',
-       				'id' => '',
-       			),
-       			'post_type' => array (
-       				0 => 'post',
-       			),
-       			'taxonomy' => array (
-       			),
-       			'filters' => array (
-       				0 => 'search',
-       				1 => 'taxonomy',
-       			),
-       			'elements' => array (
-       				0 => 'featured_image',
-       			),
-       			'min' => '',
-       			'max' => 1,
-       			'return_format' => 'id',
-       		),
-       		array (
-       			'key' => 'field_58793938460c4',
-       			'label' => __( 'Home Page Content', 'jacobin-core' ),
-       			'name' => 'home_content',
-       			'type' => 'relationship',
-       			'instructions' => '',
-       			'required' => 0,
-       			'conditional_logic' => 0,
-       			'wrapper' => array (
-       				'width' => '',
-       				'class' => '',
-       				'id' => '',
-       			),
-       			'post_type' => array (
-       				0 => 'post',
-       			),
-       			'taxonomy' => array (
-       			),
-       			'filters' => array (
-       				0 => 'search',
-       				1 => 'taxonomy',
-       			),
-       			'elements' => array (
-       				0 => 'featured_image',
-       			),
-       			'min' => '',
-       			'max' => 10,
-       			'return_format' => 'id',
-       		),
-       		array (
-       			'key' => 'field_5849024645d08',
-       			'label' => __( 'Editor\'s Pick', 'jacobin-core' ),
-       			'name' => 'editors_pick',
-       			'type' => 'relationship',
-       			'instructions' => '',
-       			'required' => 0,
-       			'conditional_logic' => 0,
-       			'wrapper' => array (
-       				'width' => '',
-       				'class' => '',
-       				'id' => '',
-       			),
-       			'post_type' => array (
-       				0 => 'post',
-       			),
-       			'taxonomy' => array (
-       			),
-       			'filters' => array (
-       				0 => 'search',
-       				1 => 'taxonomy',
-       			),
-       			'elements' => array (
-       				0 => 'featured_image',
-       			),
-       			'min' => '',
-       			'max' => 5,
-       			'return_format' => 'id',
-       		),
-       	),
-       	'location' => array (
-       		array (
-       			array (
-       				'param' => 'options_page',
-       				'operator' => '==',
-       				'value' => 'featured-content',
-       			),
-       		),
-       	),
-       	'menu_order' => 0,
-       	'position' => 'normal',
-       	'style' => 'seamless',
-       	'label_placement' => 'top',
-       	'instruction_placement' => 'label',
-       	'hide_on_screen' => '',
-       	'active' => 1,
-       	'description' => '',
+       acf_add_local_field_group( array (
+         'key' => 'group_58b9cc9382667',
+         'title' => __( 'Home Page', 'jacobin-core' ),
+         'fields' => array (
+           array (
+             'key' => 'field_58b9ced60cd1b',
+             'label' => __( 'Featured Article', 'jacobin-core' ),
+             'name' => 'home_feature',
+             'type' => 'clone',
+             'instructions' => '',
+             'required' => 0,
+             'conditional_logic' => 0,
+             'wrapper' => array (
+               'width' => '',
+               'class' => '',
+               'id' => '',
+             ),
+             'clone' => array (
+               0 => 'field_58b9ce520c8e2',
+             ),
+             'display' => 'seamless',
+             'layout' => 'block',
+             'prefix_label' => 0,
+             'prefix_name' => 1,
+           ),
+           array (
+             'key' => 'field_58b9cca81a06d',
+             'label' => __( 'Section 1', 'jacobin-core' ),
+             'name' => 'home_1',
+             'type' => 'clone',
+             'instructions' => '',
+             'required' => 0,
+             'conditional_logic' => 0,
+             'wrapper' => array (
+               'width' => '',
+               'class' => '',
+               'id' => '',
+             ),
+             'clone' => array (
+               0 => 'field_58b9cbd0ce677',
+             ),
+             'display' => 'seamless',
+             'layout' => 'block',
+             'prefix_label' => 1,
+             'prefix_name' => 1,
+           ),
+           array (
+             'key' => 'field_58b9ccf51a06e',
+             'label' => __( 'Section 2', 'jacobin-core' ),
+             'name' => 'home_2',
+             'type' => 'clone',
+             'instructions' => '',
+             'required' => 0,
+             'conditional_logic' => 0,
+             'wrapper' => array (
+               'width' => '',
+               'class' => '',
+               'id' => '',
+             ),
+             'clone' => array (
+               0 => 'field_58b9cbd0ce677',
+             ),
+             'display' => 'seamless',
+             'layout' => 'block',
+             'prefix_label' => 1,
+             'prefix_name' => 1,
+           ),
+           array (
+             'key' => 'field_58b9cd2a1a06f',
+             'label' => __( 'Section 3', 'jacobin-core' ),
+             'name' => 'home_3',
+             'type' => 'clone',
+             'instructions' => '',
+             'required' => 0,
+             'conditional_logic' => 0,
+             'wrapper' => array (
+               'width' => '',
+               'class' => '',
+               'id' => '',
+             ),
+             'clone' => array (
+               0 => 'field_58b9cbd0ce677',
+             ),
+             'display' => 'seamless',
+             'layout' => 'block',
+             'prefix_label' => 1,
+             'prefix_name' => 1,
+           ),
+         ),
+         'location' => array (
+           array (
+             array (
+               'param' => 'options_page',
+               'operator' => '==',
+               'value' => 'featured-content',
+             ),
+           ),
+         ),
+         'menu_order' => 5,
+         'position' => 'normal',
+         'style' => 'default',
+         'label_placement' => 'top',
+         'instruction_placement' => 'label',
+         'hide_on_screen' => '',
+         'active' => 1,
+         'description' => '',
        ));
+
+
+       acf_add_local_field_group( array (
+         'key' => 'group_editorspick056',
+         'title' => __( 'Editor\'s Picks', 'jacobin-core' ),
+         'fields' => array (
+           array (
+             'key' => 'field_5849024645d08',
+             'label' => __( '', 'jacobin-core' ),
+             'name' => 'editors_pick',
+             'type' => 'clone',
+             'instructions' => '',
+             'required' => 0,
+             'conditional_logic' => 0,
+             'wrapper' => array (
+               'width' => '',
+               'class' => '',
+               'id' => '',
+             ),
+             'clone' => array (
+               0 => 'field_58b9cbd0ce677',
+             ),
+             'display' => 'seamless',
+             'layout' => 'block',
+             'prefix_label' => 1,
+             'prefix_name' => 1,
+           ),
+         ),
+         'location' => array (
+           array (
+             array (
+               'param' => 'options_page',
+               'operator' => '==',
+               'value' => 'featured-content',
+             ),
+           ),
+         ),
+         'menu_order' => 10,
+         'position' => 'normal',
+         'style' => 'default',
+         'label_placement' => 'top',
+         'instruction_placement' => 'label',
+         'hide_on_screen' => '',
+         'active' => 1,
+         'description' => '',
+       ));
+
 
      }
 

--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -27,8 +27,9 @@
      function __construct() {
 
          if( function_exists( 'register_field_group' ) ) {
-             $this->register_field_groups();
-             $this->register_settings_fields();
+           $this->register_clone_fields();
+           $this->register_field_groups();
+           $this->register_settings_fields();
          }
      }
 
@@ -44,87 +45,176 @@
       * @return void
       */
      public function register_clone_fields() {
-       acf_add_local_field_group(array (
-        	'key' => 'group_58b9cbbf18c46',
-        	'title' => 'Featured Posts',
-        	'fields' => array (
-        		array (
-        			'key' => 'field_58b9cbd0ce677',
-        			'label' => 'Featured Posts (5 max)',
-        			'name' => 'featured_posts',
-        			'type' => 'relationship',
-        			'instructions' => '',
-        			'required' => 0,
-        			'conditional_logic' => 0,
-        			'wrapper' => array (
-        				'width' => '',
-        				'class' => '',
-        				'id' => '',
-        			),
-        			'post_type' => array (
-        				0 => 'post',
-        			),
-        			'taxonomy' => array (
-        			),
-        			'filters' => array (
-        				0 => 'search',
-        				1 => 'taxonomy',
-        			),
-        			'elements' => array (
-        				0 => 'featured_image',
-        			),
-        			'min' => 1,
-        			'max' => 5,
-        			'return_format' => 'id',
-        		),
-        		array (
-        			'key' => 'field_58b9ce520c8e2',
-        			'label' => 'Featured Post (Single)',
-        			'name' => 'featured_post',
-        			'type' => 'relationship',
-        			'instructions' => '',
-        			'required' => 0,
-        			'conditional_logic' => 0,
-        			'wrapper' => array (
-        				'width' => '',
-        				'class' => '',
-        				'id' => '',
-        			),
-        			'post_type' => array (
-        				0 => 'post',
-        			),
-        			'taxonomy' => array (
-        			),
-        			'filters' => array (
-        				0 => 'search',
-        				1 => 'taxonomy',
-        			),
-        			'elements' => array (
-        				0 => 'featured_image',
-        			),
-        			'min' => 1,
-        			'max' => 1,
-        			'return_format' => 'id',
-        		),
-        	),
-        	'location' => array (
-        		array (
-        			array (
-        				'param' => 'post_type',
-        				'operator' => '==',
-        				'value' => 'post',
-        			),
-        		),
-        	),
-        	'menu_order' => 0,
-        	'position' => 'normal',
-        	'style' => 'default',
-        	'label_placement' => 'top',
-        	'instruction_placement' => 'label',
-        	'hide_on_screen' => '',
-        	'active' => 0,
-        	'description' => '',
-        ));
+
+       acf_add_local_field_group( array (
+       	'key' => 'group_58b9cbbf18c46',
+       	'title' => 'Featured Posts',
+       	'fields' => array (
+       		array (
+       			'key' => 'field_clonefeatured1',
+       			'label' => 'Featured Post (Single)',
+       			'name' => 'featured_post_1',
+       			'type' => 'relationship',
+       			'instructions' => '',
+       			'required' => 0,
+       			'conditional_logic' => 0,
+       			'wrapper' => array (
+       				'width' => '',
+       				'class' => '',
+       				'id' => '',
+       			),
+       			'post_type' => array (
+       				0 => 'post',
+       			),
+       			'taxonomy' => array (
+       			),
+       			'filters' => array (
+       				0 => 'search',
+       				1 => 'taxonomy',
+       			),
+       			'elements' => array (
+       				0 => 'featured_image',
+       			),
+       			'min' => 1,
+       			'max' => 1,
+       			'return_format' => 'id',
+       		),
+       		array (
+       			'key' => 'field_clonefeatured5',
+       			'label' => 'Featured Posts (5 max)',
+       			'name' => 'featured_posts_5',
+       			'type' => 'relationship',
+       			'instructions' => '',
+       			'required' => 0,
+       			'conditional_logic' => 0,
+       			'wrapper' => array (
+       				'width' => '',
+       				'class' => '',
+       				'id' => '',
+       			),
+       			'post_type' => array (
+       				0 => 'post',
+       			),
+       			'taxonomy' => array (
+       			),
+       			'filters' => array (
+       				0 => 'search',
+       				1 => 'taxonomy',
+       			),
+       			'elements' => array (
+       				0 => 'featured_image',
+       			),
+       			'min' => 1,
+       			'max' => 5,
+       			'return_format' => 'id',
+       		),
+       		array (
+       			'key' => 'field_clonefeatured10',
+       			'label' => 'Featured Posts (10 max)',
+       			'name' => 'featured_posts_10',
+       			'type' => 'relationship',
+       			'instructions' => '',
+       			'required' => 0,
+       			'conditional_logic' => 0,
+       			'wrapper' => array (
+       				'width' => '',
+       				'class' => '',
+       				'id' => '',
+       			),
+       			'post_type' => array (
+       				0 => 'post',
+       			),
+       			'taxonomy' => array (
+       			),
+       			'filters' => array (
+       				0 => 'search',
+       				1 => 'taxonomy',
+       			),
+       			'elements' => array (
+       				0 => 'featured_image',
+       			),
+       			'min' => 1,
+       			'max' => 10,
+       			'return_format' => 'id',
+       		),
+       		array (
+       			'key' => 'field_clonefeatured15',
+       			'label' => 'Featured Posts (15 max)',
+       			'name' => 'featured_posts_15',
+       			'type' => 'relationship',
+       			'instructions' => '',
+       			'required' => 0,
+       			'conditional_logic' => 0,
+       			'wrapper' => array (
+       				'width' => '',
+       				'class' => '',
+       				'id' => '',
+       			),
+       			'post_type' => array (
+       				0 => 'post',
+       			),
+       			'taxonomy' => array (
+       			),
+       			'filters' => array (
+       				0 => 'search',
+       				1 => 'taxonomy',
+       			),
+       			'elements' => array (
+       				0 => 'featured_image',
+       			),
+       			'min' => 1,
+       			'max' => 15,
+       			'return_format' => 'id',
+       		),
+       		array (
+       			'key' => 'field_clonefeatured20',
+       			'label' => 'Featured Posts (20 max)',
+       			'name' => 'featured_posts_20',
+       			'type' => 'relationship',
+       			'instructions' => '',
+       			'required' => 0,
+       			'conditional_logic' => 0,
+       			'wrapper' => array (
+       				'width' => '',
+       				'class' => '',
+       				'id' => '',
+       			),
+       			'post_type' => array (
+       				0 => 'post',
+       			),
+       			'taxonomy' => array (
+       			),
+       			'filters' => array (
+       				0 => 'search',
+       				1 => 'taxonomy',
+       			),
+       			'elements' => array (
+       				0 => 'featured_image',
+       			),
+       			'min' => 1,
+       			'max' => 20,
+       			'return_format' => 'id',
+       		),
+       	),
+       	'location' => array (
+       		array (
+       			array (
+       				'param' => 'post_type',
+       				'operator' => '==',
+       				'value' => 'post',
+       			),
+       		),
+       	),
+       	'menu_order' => 0,
+       	'position' => 'normal',
+       	'style' => 'default',
+       	'label_placement' => 'top',
+       	'instruction_placement' => 'label',
+       	'hide_on_screen' => '',
+       	'active' => 0,
+       	'description' => '',
+       ));
+
      }
 
      /**
@@ -140,7 +230,7 @@
        /**
         * Post Default Custom Fields
         */
-       acf_add_local_field_group(array (
+       acf_add_local_field_group( array (
        	'key' => 'group_5771c00b7ae29',
        	'title' => __( 'Article Details', 'jacobin-core' ),
        	'fields' => array (
@@ -1807,159 +1897,200 @@
        /**
         * Featured Content Options Page Fields
         */
-       acf_add_local_field_group( array (
-         'key' => 'group_58b9cc9382667',
-         'title' => __( 'Home Page', 'jacobin-core' ),
-         'fields' => array (
-           array (
-             'key' => 'field_58b9ced60cd1b',
-             'label' => __( 'Featured Article', 'jacobin-core' ),
-             'name' => 'home_feature',
-             'type' => 'clone',
-             'instructions' => '',
-             'required' => 0,
-             'conditional_logic' => 0,
-             'wrapper' => array (
-               'width' => '',
-               'class' => '',
-               'id' => '',
-             ),
-             'clone' => array (
-               0 => 'field_58b9ce520c8e2',
-             ),
-             'display' => 'seamless',
-             'layout' => 'block',
-             'prefix_label' => 0,
-             'prefix_name' => 1,
-           ),
-           array (
-             'key' => 'field_58b9cca81a06d',
-             'label' => __( 'Section 1', 'jacobin-core' ),
-             'name' => 'home_1',
-             'type' => 'clone',
-             'instructions' => '',
-             'required' => 0,
-             'conditional_logic' => 0,
-             'wrapper' => array (
-               'width' => '',
-               'class' => '',
-               'id' => '',
-             ),
-             'clone' => array (
-               0 => 'field_58b9cbd0ce677',
-             ),
-             'display' => 'seamless',
-             'layout' => 'block',
-             'prefix_label' => 1,
-             'prefix_name' => 1,
-           ),
-           array (
-             'key' => 'field_58b9ccf51a06e',
-             'label' => __( 'Section 2', 'jacobin-core' ),
-             'name' => 'home_2',
-             'type' => 'clone',
-             'instructions' => '',
-             'required' => 0,
-             'conditional_logic' => 0,
-             'wrapper' => array (
-               'width' => '',
-               'class' => '',
-               'id' => '',
-             ),
-             'clone' => array (
-               0 => 'field_58b9cbd0ce677',
-             ),
-             'display' => 'seamless',
-             'layout' => 'block',
-             'prefix_label' => 1,
-             'prefix_name' => 1,
-           ),
-           array (
-             'key' => 'field_58b9cd2a1a06f',
-             'label' => __( 'Section 3', 'jacobin-core' ),
-             'name' => 'home_3',
-             'type' => 'clone',
-             'instructions' => '',
-             'required' => 0,
-             'conditional_logic' => 0,
-             'wrapper' => array (
-               'width' => '',
-               'class' => '',
-               'id' => '',
-             ),
-             'clone' => array (
-               0 => 'field_58b9cbd0ce677',
-             ),
-             'display' => 'seamless',
-             'layout' => 'block',
-             'prefix_label' => 1,
-             'prefix_name' => 1,
-           ),
-         ),
-         'location' => array (
-           array (
-             array (
-               'param' => 'options_page',
-               'operator' => '==',
-               'value' => 'featured-content',
-             ),
-           ),
-         ),
-         'menu_order' => 5,
-         'position' => 'normal',
-         'style' => 'default',
-         'label_placement' => 'top',
-         'instruction_placement' => 'label',
-         'hide_on_screen' => '',
-         'active' => 1,
-         'description' => '',
-       ));
+        acf_add_local_field_group( array (
+        	'key' => 'group_58b9cc9382667',
+        	'title' => __( 'Home Page', 'jacobin-core' ),
+        	'fields' => array (
+        		array (
+        			'key' => 'field_58b9ced60cd1b',
+        			'label' => __( 'Featured Article (single)', 'jacobin-core' ),
+        			'name' => 'home_feature',
+        			'type' => 'clone',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'clone' => array (
+        				0 => 'field_clonefeatured1',
+        			),
+        			'display' => 'seamless',
+        			'layout' => 'block',
+        			'prefix_label' => 0,
+        			'prefix_name' => 1,
+        		),
+        		array (
+        			'key' => 'field_58b9cca81a06d',
+        			'label' => __( 'Section 1', 'jacobin-core' ),
+        			'name' => 'home_1',
+        			'type' => 'clone',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'clone' => array (
+        				0 => 'field_clonefeatured5',
+        			),
+        			'display' => 'seamless',
+        			'layout' => 'block',
+        			'prefix_label' => 1,
+        			'prefix_name' => 1,
+        		),
+        		array (
+        			'key' => 'field_58b9ccf51a06e',
+        			'label' => __( 'Section 2', 'jacobin-core' ),
+        			'name' => 'home_2',
+        			'type' => 'clone',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'clone' => array (
+        				0 => 'field_clonefeatured5',
+        			),
+        			'display' => 'seamless',
+        			'layout' => 'block',
+        			'prefix_label' => 1,
+        			'prefix_name' => 1,
+        		),
+        		array (
+        			'key' => 'field_58b9cd2a1a06f',
+        			'label' => __( 'Section 3', 'jacobin-core' ),
+        			'name' => 'home_3',
+        			'type' => 'clone',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'clone' => array (
+        				0 => 'field_clonefeatured5',
+        			),
+        			'display' => 'seamless',
+        			'layout' => 'block',
+        			'prefix_label' => 1,
+        			'prefix_name' => 1,
+        		),
+        		array (
+        			'key' => 'field_58ba18867d794',
+        			'label' => __( 'Section 4', 'jacobin-core' ),
+        			'name' => 'home_4',
+        			'type' => 'clone',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'clone' => array (
+        				0 => 'field_clonefeatured10',
+        			),
+        			'display' => 'seamless',
+        			'layout' => 'block',
+        			'prefix_label' => 1,
+        			'prefix_name' => 1,
+        		),
+        		array (
+        			'key' => 'field_58ba18a87d795',
+        			'label' => __( 'Section 5', 'jacobin-core' ),
+        			'name' => 'home_5',
+        			'type' => 'clone',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'clone' => array (
+        				0 => 'field_clonefeatured15',
+        			),
+        			'display' => 'seamless',
+        			'layout' => 'block',
+        			'prefix_label' => 1,
+        			'prefix_name' => 1,
+        		),
+        	),
+        	'location' => array (
+        		array (
+        			array (
+                'param' => 'options_page',
+                'operator' => '==',
+                'value' => 'featured-content',
+        			),
+        		),
+        	),
+        	'menu_order' => 0,
+        	'position' => 'normal',
+        	'style' => 'default',
+        	'label_placement' => 'top',
+        	'instruction_placement' => 'label',
+        	'hide_on_screen' => '',
+        	'active' => 1,
+        	'description' => '',
+        ));
 
-
-       acf_add_local_field_group( array (
-         'key' => 'group_editorspick056',
-         'title' => __( 'Editor\'s Picks', 'jacobin-core' ),
-         'fields' => array (
-           array (
-             'key' => 'field_5849024645d08',
-             'label' => __( '', 'jacobin-core' ),
-             'name' => 'editors_pick',
-             'type' => 'clone',
-             'instructions' => '',
-             'required' => 0,
-             'conditional_logic' => 0,
-             'wrapper' => array (
-               'width' => '',
-               'class' => '',
-               'id' => '',
-             ),
-             'clone' => array (
-               0 => 'field_58b9cbd0ce677',
-             ),
-             'display' => 'seamless',
-             'layout' => 'block',
-             'prefix_label' => 1,
-             'prefix_name' => 1,
-           ),
-         ),
-         'location' => array (
-           array (
-             array (
-               'param' => 'options_page',
-               'operator' => '==',
-               'value' => 'featured-content',
-             ),
-           ),
-         ),
-         'menu_order' => 10,
-         'position' => 'normal',
-         'style' => 'default',
-         'label_placement' => 'top',
-         'instruction_placement' => 'label',
-         'hide_on_screen' => '',
-         'active' => 1,
-         'description' => '',
-       ));
+        acf_add_local_field_group( array (
+        	'key' => 'group_editorspicks',
+        	'title' => __( 'Editor\'s Picks', 'jacobin-core' ),
+        	'fields' => array (
+        		array (
+        			'key' => 'field_editorspick',
+        			'label' => __( 'Editor\'s Picks (max 5)', 'jacobin-core' ),
+        			'name' => 'editors_pick',
+        			'type' => 'clone',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'clone' => array (
+        				0 => 'field_clonefeatured5',
+        			),
+        			'display' => 'seamless',
+        			'layout' => 'block',
+        			'prefix_label' => 0,
+        			'prefix_name' => 1,
+        		),
+        	),
+        	'location' => array (
+        		array (
+        			array (
+                'param' => 'options_page',
+                'operator' => '==',
+                'value' => 'featured-content',
+        			),
+        		),
+        	),
+        	'menu_order' => 10,
+        	'position' => 'normal',
+        	'style' => 'default',
+        	'label_placement' => 'top',
+        	'instruction_placement' => 'label',
+        	'hide_on_screen' => '',
+        	'active' => 1,
+        	'description' => '',
+        ));
 
 
      }

--- a/includes/class-jacobin-core-register-routes.php
+++ b/includes/class-jacobin-core-register-routes.php
@@ -142,19 +142,19 @@ class Jacobin_Rest_API_Routes {
         $slug  = $request->get_param( 'slug' );
 
         $options = array(
-          'home-feature'  => 'options_home_feature_featured_post',
-          'home-1'        => 'options_home_1_featured_posts',
-          'home-2'        => 'options_home_2_featured_posts',
-          'home-3'        => 'options_home_3_featured_posts',
-          'home-4'        => 'options_home_4_featured_posts',
-          'home-5'        => 'options_home_5_featured_posts',
-          'editors-picks' => 'options_editors_pick_featured_posts'
+          'home-feature'  => 'options_home_feature_featured_post_1',
+          'home-1'        => 'options_home_1_featured_posts_5',
+          'home-2'        => 'options_home_2_featured_posts_5',
+          'home-3'        => 'options_home_3_featured_posts_5',
+          'home-4'        => 'options_home_4_featured_posts_10',
+          'home-5'        => 'options_home_5_featured_posts_15',
+          'editors-picks' => 'options_editors_pick_featured_posts_5'
         );
 
         $option = get_option( $options[$slug] );
 
         if( empty( $option ) || is_wp_error( $option ) ) {
-            return new WP_Error( 'rest_no_post', __( 'No posts were found', 'jacobin-core' ), array( 'status' => 404 ) );
+            return new WP_Error( 'rest_no_posts', __( 'No posts were found', 'jacobin-core' ), array( 'status' => 404 ) );
         }
 
         $posts_ids = array_map(
@@ -174,6 +174,7 @@ class Jacobin_Rest_API_Routes {
                 $post->{"date"} = $post_detail->post_date;
                 $post->{"title"}["rendered"] = esc_attr( $post_detail->post_title );
                 $post->{"subhead"} = get_post_meta( $post_id, 'subhead', true );
+                $post->{"excerpt"}["rendered"] = esc_attr( $post_detail->post_excerpt );
                 $post->{"slug"} = $post_detail->post_name;
                 $post->{"authors"} = jacobin_get_authors_array( $post_id );
                 $post->{"departments"} = jacobin_get_post_terms( $post_id, 'department' );

--- a/jacobin-core-functionality.php
+++ b/jacobin-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     jacobin-core
  * Domain Path:     /languages
  *
- * Version:         0.2.6.1
+ * Version:         0.2.7
  *
  * @package         Core_Functionality
  */
@@ -53,7 +53,7 @@ require_once( 'utils/copy-content.php' );
  * @return object Jacobin_Core
  */
 function Jacobin_Core () {
-	$instance = Jacobin_Core::instance( __FILE__, '0.2.6.1' );
+	$instance = Jacobin_Core::instance( __FILE__, '0.2.7' );
 
 	return $instance;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -26,7 +26,26 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 0.2.7 March 3, 2017 =
-* Modify Featured Content to split Home into sections
+* Modified Featured Content to split Home into sections
+  * `/wp-json/jacobin/featured-content?slug=home-feature`
+  * `/wp-json/jacobin/featured-content/home-feature`
+
+  ```
+  "enum": [
+    "home-feature",
+    "home-1",
+    "home-2",
+    "home-3",
+    "home-4",
+    "home-5",
+    "editors-picks"
+  ],
+  ```
+* Added 2 additional featured content fields: `home_4` and `home_5`
+* Added `excerpt` to Featured Content response
+* Modified post admin screen
+  * Moved Excerpt into Article Details section
+  * Moved Authors below Publish section in right column
 
 = 0.2.6.1 March 2, 2017 =
 * #171 added `term_id` and `author_posts` link to endpoint `/wp-json/wp/v2/guest-author`

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: misfist
 Tags: custom post type, custom taxonomy, rest api
 Requires at least: 4.7
 Tested up to: 4.7.2
-Version: 0.2.6.1
+Version: 0.2.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 0.2.7 March 3, 2017 =
+* Modify Featured Content to split Home into sections
 
 = 0.2.6.1 March 2, 2017 =
 * #171 added `term_id` and `author_posts` link to endpoint `/wp-json/wp/v2/guest-author`


### PR DESCRIPTION
* Modified Featured Content to split Home into sections
  * `/wp-json/jacobin/featured-content?slug=home-feature`
  * `/wp-json/jacobin/featured-content/home-feature`

  ```
  "enum": [
    "home-feature",
    "home-1",
    "home-2",
    "home-3",
    "home-4",
    "home-5",
    "editors-picks"
  ],
  ```
* Added 2 additional featured content fields: `home_4` and `home_5`
* Added `excerpt` to Featured Content response
* Modified post admin screen
  * Moved Excerpt into Article Details section
  * Moved Authors below Publish section in right column