### PR TITLE
Addressed Open Tickets

### DIFF
--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -1533,7 +1533,9 @@
        			'filters' => array (
        				0 => 'search',
        			),
-       			'elements' => '',
+            'elements' => array (
+       				0 => 'featured_image',
+       			),
        			'return_format' => 'id',
        		),
        		array (
@@ -1638,7 +1640,69 @@
        /**
         * Issue Post Type Custom Fields
         */
-       acf_add_local_field_group(array (
+        acf_add_local_field_group(array (
+        	'key' => 'group_58c998325fdcc',
+        	'title' => 'Issue',
+        	'fields' => array (
+        		array (
+        			'key' => 'field_57cb88a7b0567',
+        			'label' => __( 'Number', 'jacobin-core' ),
+        			'name' => 'issue_number',
+              'type' => 'text',
+              'instructions' => '',
+              'required' => 1,
+              'conditional_logic' => 0,
+              'wrapper' => array (
+                'width' => '',
+                'class' => '',
+                'id' => '',
+              ),
+              'default_value' => '',
+              'placeholder' => '',
+              'prepend' => __( 'Issue', 'jacobin-core' ),
+              'append' => '',
+              'maxlength' => '',
+        		),
+        		array (
+        			'key' => 'field_issue_season',
+        			'label' => __( 'Season', 'jacobin-core' ),
+        			'name' => 'issue_season',
+        			'type' => 'text',
+        			'instructions' => '',
+        			'required' => 0,
+        			'conditional_logic' => 0,
+        			'wrapper' => array (
+        				'width' => '',
+        				'class' => '',
+        				'id' => '',
+        			),
+        			'default_value' => '',
+        			'placeholder' => 'Spring 2019',
+        			'prepend' => '',
+        			'append' => '',
+        			'maxlength' => '',
+        		),
+        	),
+        	'location' => array (
+        		array (
+        			array (
+        				'param' => 'post_type',
+        				'operator' => '==',
+        				'value' => 'issue',
+        			),
+        		),
+        	),
+        	'menu_order' => 0,
+        	'position' => 'side',
+        	'style' => 'default',
+        	'label_placement' => 'top',
+        	'instruction_placement' => 'label',
+        	'hide_on_screen' => '',
+        	'active' => 1,
+        	'description' => '',
+        ));
+
+       acf_add_local_field_group( array(
        	'key' => 'group_5771c00b6d7c6',
        	'title' => __( 'Issue Details', 'jacobin-core' ),
        	'fields' => array (
@@ -1685,25 +1749,6 @@
        			'new_lines' => 'wpautop',
        			'readonly' => 0,
        			'disabled' => 0,
-       		),
-       		array (
-       			'key' => 'field_57cb88a7b0567',
-       			'label' => __( 'Issue Number', 'jacobin-core' ),
-       			'name' => 'issue_number',
-       			'type' => 'text',
-       			'instructions' => '',
-       			'required' => 1,
-       			'conditional_logic' => 0,
-       			'wrapper' => array (
-       				'width' => '',
-       				'class' => '',
-       				'id' => '',
-       			),
-       			'default_value' => '',
-       			'placeholder' => '',
-       			'prepend' => '',
-       			'append' => '',
-       			'maxlength' => '',
        		),
        		array (
        			'key' => 'field_5761b4a265e4e',

--- a/includes/class-jacobin-core-field-settings.php
+++ b/includes/class-jacobin-core-field-settings.php
@@ -43,6 +43,10 @@ class Jacobin_Field_Settings {
 
         add_filter( 'acf/fields/flexible_content/no_value_message', array( $this, 'modify_acf_flexible_content_message' ) );
 
+        add_filter( 'acf/fields/relationship/query/name=translator', array( $this, 'relationship_options_filter' ) , 10, 3 );
+        add_filter( 'acf/fields/relationship/query/name=interviewer', array( $this, 'relationship_options_filter' ) , 10, 3 );
+        add_filter( 'acf/fields/relationship/query/name=name', array( $this, 'relationship_options_filter' ) , 10, 3 );
+        add_filter( 'acf/fields/relationship/query/name=cover_artist', array( $this, 'relationship_options_filter' ) , 10, 3 );
      }
 
     /**
@@ -51,6 +55,27 @@ class Jacobin_Field_Settings {
      * @since 0.1.0
      */
     function register() {}
+
+
+    /**
+     * Filter out unpublished posts
+     * Relationship fields will only show posts where `post_status = publish`
+     *
+     * @since 0.2.8
+     *
+     * @access public
+     *
+     * @param  array $options
+     * @param  string $field
+     * @param  obj $the_post
+     * @return array $options
+     */
+    public function relationship_options_filter( $options, $field, $the_post ) {
+
+    	$options['post_status'] = array( 'publish' );
+
+    	return $options;
+    }
 
     /**
      * Remove standard WordPress metaboxes for custom taxonomies.

--- a/includes/class-jacobin-core-register-fields.php
+++ b/includes/class-jacobin-core-register-fields.php
@@ -24,15 +24,6 @@ class Jacobin_Rest_API_Fields {
      */
     function __construct () {
         /**
-         * Filters to have fields returned in `custom_fields` instead of `acf`.
-         */
-        //add_filter( 'acf/rest_api/post/get_fields', array( $this, 'set_custom_field_base' ) );
-        add_filter( 'acf/rest_api/issue/get_fields', array( $this, 'set_custom_field_base' ) );
-        add_filter( 'acf/rest_api/term/get_fields', array( $this, 'set_custom_field_base' ) );
-        add_filter( 'acf/rest_api/timeline/get_fields', array( $this, 'set_custom_field_base' ) );
-        add_filter( 'acf/rest_api/chart/get_fields', array( $this, 'set_custom_field_base' ) );
-
-        /**
          * Modify Responses
          */
         add_filter( 'rest_prepare_post', array( $this, 'modify_post_response_taxonomy' ), 10, 3 );
@@ -142,6 +133,24 @@ class Jacobin_Rest_API_Fields {
                     'update_callback' => null,
                     'schema'          => null,
                 )
+            );
+
+            register_rest_field( 'issue',
+              'issue_number',
+              array(
+                'get_callback'      => array( $this, 'get_field' ),
+                'update_callback'   => null,
+                'schema'            => null
+              )
+            );
+
+            register_rest_field( 'issue',
+              'issue_season',
+              array(
+                'get_callback'      => array( $this, 'get_field' ),
+                'update_callback'   => null,
+                'schema'            => null
+              )
             );
 
             register_rest_field( 'department',
@@ -345,7 +354,7 @@ class Jacobin_Rest_API_Fields {
     function get_featured_post_post( $object, $field_name, $request ) {
         $featured = get_post_meta(  $object[ 'id' ], $field_name, true );
         $featured_id = ( !empty( $featured ) && is_array( $featured ) ) ? (int) $featured[0] : false;
-        return ( !empty( $featured_id ) ) ? jacobin_get_post_data( $featured_id ) : false;
+        return ( !empty( $featured_id ) ) ? jacobin_get_related_post_data( $featured_id ) : false;
     }
 
     /**
@@ -362,7 +371,7 @@ class Jacobin_Rest_API_Fields {
     function get_featured_post_term( $object, $field_name, $request ) {
         $featured = get_term_meta(  $object[ 'id' ], $field_name, true );
         $featured_id = ( !empty( $featured ) && is_array( $featured ) ) ? (int) $featured[0] : false;
-        return ( !empty( $featured_id ) ) ? jacobin_get_post_data( $featured_id ) : false;
+        return ( !empty( $featured_id ) ) ? jacobin_get_related_post_data( $featured_id ) : false;
     }
 
     /**
@@ -573,55 +582,6 @@ class Jacobin_Rest_API_Fields {
 
         return false;
 
-    }
-
-    /**
-     * Change Base Label of Custom Fields
-     *
-     * Advanced Custom Fields fields are displayed within `acf`.
-     *
-     * @link https://github.com/airesvsg/acf-to-rest-api/issues/41#issuecomment-222460783
-     *
-     * @param array $data
-     * @return modified array $data
-     *
-     * @since 0.1.0
-     */
-    public function set_custom_field_base ( $data ) {
-        if ( method_exists( $data, 'get_data' ) ) {
-            $data = $data->get_data();
-        } else {
-            $data = (array) $data;
-        }
-
-        if ( isset( $data['acf'] ) ) {
-            $data['custom_fields'] = $data['acf'];
-            unset( $data['acf'] );
-        }
-        return $data;
-    }
-
-    /**
-     * Change response field to `custom_fields`.
-     *
-     * @since 0.1.0
-     *
-     * @param $response
-     * @param $object
-     * @return modified $response
-     *
-     * @link http://v2.wp-api.org/extending/custom-content-types/
-     */
-    public function rest_prepare_term ( $response, $object ) {
-        if ( $object instanceof WP_Term && function_exists( 'get_fields' ) ) {
-            if ( isset( $data['acf'] ) ) {
-                $data['custom_fields'] = $data['acf'];
-                unset( $data['acf'] );
-            }
-            $response->data['custom_fields'] = get_fields( $object->taxonomy . '_' . $object->term_id );
-        }
-
-        return $response;
     }
 
 }

--- a/jacobin-core-functionality.php
+++ b/jacobin-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     jacobin-core
  * Domain Path:     /languages
  *
- * Version:         0.2.7.2
+ * Version:         0.2.8
  *
  * @package         Core_Functionality
  */
@@ -53,7 +53,7 @@ require_once( 'utils/copy-content.php' );
  * @return object Jacobin_Core
  */
 function Jacobin_Core () {
-	$instance = Jacobin_Core::instance( __FILE__, '0.2.7.2' );
+	$instance = Jacobin_Core::instance( __FILE__, '0.2.8' );
 
 	return $instance;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: misfist
 Tags: custom post type, custom taxonomy, rest api
 Requires at least: 4.7
 Tested up to: 4.7.2
-Version: 0.2.7.2
+Version: 0.2.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,14 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 0.2.8 March 15, 2017 =
+* #178 Added `issue_season` field to issue post type and registered in REST API
+* #165 Replicated `better_featured_image` response for all endpoints
+* #177 Added slug to author response - comes from `cap-user_login` field in `guest-author` post
+* #163 Added `subhead` and `authors` for the featured articles in `department` and `issue` responses
+* Changed `custom_fields` property to default `acf`
+* Limited related post lists to post = `publish`
 
 = 0.2.7.2 March 8, 2017 =
 * Enabled `guest-authors` to be retrieve using `id` ( `?id={id}` ) and `term_id` ( `?term_id={term_id}` )


### PR DESCRIPTION
* [#178](https://github.com/positiondev/jacobin/issues/178) Added `issue_season` field to issue post type and registered in REST API
* [#165](https://github.com/positiondev/jacobin/issues/165) Replicated `better_featured_image` response for all endpoints
* [#177](https://github.com/positiondev/jacobin/issues/177) Added slug to author response - comes from `cap-user_login` field in `guest-author` post
* [#163](https://github.com/positiondev/jacobin/issues/163) Added `subhead` and `authors` for the featured articles in `department` and `issue` responses
* Changed `custom_fields` property to default `acf`
* Limited related post lists to post = `publish`