### PR TITLE
#326 Added `meta_content` text filters and applied to subhead fields.

### DIFF
--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -33,6 +33,8 @@
          }
 
          add_filter( 'coauthors_guest_author_fields', array( $this, 'add_guest_author_fields' ), 10, 2 );
+
+         $this->text_filters();
      }
 
      /**
@@ -2296,6 +2298,18 @@
        	} else {
        		return null;
         }
+     }
+
+     /**
+      * Text Filters for Custom Fields
+      *
+      * @since 0.3.18
+      *
+      * @return void
+      */
+     public function text_filters() {
+       add_filter( 'meta_content', 'wptexturize' );
+       add_filter( 'meta_content', 'convert_chars' );
      }
  }
 

--- a/includes/class-jacobin-core-register-routes.php
+++ b/includes/class-jacobin-core-register-routes.php
@@ -228,8 +228,8 @@ class Jacobin_Rest_API_Routes {
 
                 $post_data->{"id"} = $post->ID;
                 $post_data->{"date"} = $post->post_date;
-                $post_data->{"title"}["rendered"] = $post->post_title;
-                $post_data->{"subhead"} = get_post_meta( $post_id, 'subhead', true );
+                $post_data->{"title"}["rendered"] = get_the_title( $post_id );
+                $post_data->{"subhead"} = apply_filters( 'meta_content', get_post_meta( $post_id, 'subhead', true ) );
                 $post_data->{"excerpt"}["rendered"] = esc_attr( $post->post_excerpt );
                 $post_data->{"slug"} = $post->post_name;
                 $post_data->{"authors"} = jacobin_get_authors_array( $post_id );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -36,14 +36,14 @@ function jacobin_get_post_data( $post_id ) {
     $post_data = array(
         'id'        => $post_id,
         'title'     => array(
-            'rendered'  => $post->post_title,
+            'rendered'  => get_the_title( $post->ID ),
         ),
         'date'      => $post->post_date,
         'slug'      => $post->post_name,
         'excerpt'   => array(
             'rendered'    => jacobin_the_excerpt( $post_id ),
         ),
-        'subhead'   => get_post_meta( $post_id, 'subhead', true ),
+        'subhead'   => apply_filters( 'meta_content', get_post_meta( $post_id, 'subhead', true ) ),
         'authors'   => jacobin_get_authors_array( $post_id ),
         'departments' => jacobin_get_post_terms( $post_id, 'department' ),
     );
@@ -82,7 +82,7 @@ function jacobin_get_image_meta( $image_id ) {
     $meta = array(
         'id'            => $image_id,
         'title'         => array(
-            'rendered'  => $image_data->post_title
+            'rendered'  => esc_attr( $image_data->post_title )
         ),
         'alt_text'      => get_post_meta( $image_id  , '_wp_attachment_image_alt', true ),
         'caption'       => $image_data->post_excerpt,

--- a/jacobin-core-functionality.php
+++ b/jacobin-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     jacobin-core
  * Domain Path:     /languages
  *
- * Version:         0.3.17
+ * Version:         0.3.18
  *
  * @package         Core_Functionality
  */
@@ -54,7 +54,7 @@ require_once( 'admin/class-jacobin-core-admin.php' );
  * @return object Jacobin_Core
  */
 function Jacobin_Core () {
-	$instance = Jacobin_Core::instance( __FILE__, '0.3.17' );
+	$instance = Jacobin_Core::instance( __FILE__, '0.3.18' );
 
 	return $instance;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: misfist
 Tags: custom post type, custom taxonomy, rest api
 Requires at least: 4.7
 Tested up to: 4.8.0
-Version: 0.3.17
+Version: 0.3.18
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,10 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 0.3.18 Septembere 21, 2017 =
+* #326 Modified featured content (``/wp-json/jacobin/featured-content/{slug}/``) rendered title to use default filters
+* #326 Added `meta_content` text filters and applied to subhead fields.
 
 = 0.3.17 September 12, 2017 =
 * Removed Interviewer field group


### PR DESCRIPTION
* #326 Added `meta_content` text filters and applied to subhead fields. 

https://github.com/positiondev/jacobin/issues/326