### PR TITLE
#332 #334

### DIFF
--- a/admin/class-jacobin-core-admin.php
+++ b/admin/class-jacobin-core-admin.php
@@ -83,6 +83,12 @@ class Jacobin_Core_Admin {
 		add_filter( 'timeline_register_args', array( $this, 'modify_timeline_args' ), 'timeline' );
 		add_filter( 'chart_register_args', array( $this, 'modify_chart_args' ), 'chart' );
 
+		/**
+		 * Modify Status Tax Args
+		 * @since 0.3.19
+		 */
+		add_filter( 'status-internal_register_args', array( $this, 'modify_status_taxonomy_args' ) );
+
 	}
 
 
@@ -253,6 +259,29 @@ class Jacobin_Core_Admin {
 	public function modify_chart_args( $args ) {
 	    $args['menu_icon'] = 'dashicons-chart-line';
 	    return $args;
+	}
+
+	/**
+	 * Modify Status Taxonomy Args
+	 *
+	 * @access public
+	 *
+	 * @since 0.3.19
+	 *
+	 * @param array $args
+	 * @return array $args
+	 */
+	public function modify_status_taxonomy_args( $args ) {
+		$args['public'] = false;
+		$args['show_in_nav_menus'] = false;
+		$args['show_tagcloud'] = false;
+		$args['show_in_rest'] = false;
+		$args['rest_controller_class'] = false;
+		$args['rest_base'] = false;
+		$args['rewrite'] = false;
+		$args['description'] = __( 'For Internal Use', 'jacobin-core' );
+
+		return $args;
 	}
 
 	/**

--- a/includes/class-jacobin-core-register-fields.php
+++ b/includes/class-jacobin-core-register-fields.php
@@ -377,7 +377,13 @@ class Jacobin_Rest_API_Fields {
      *
      */
     public function get_field ( $object, $field_name, $request ) {
-        return get_post_meta( $object[ 'id' ], $field_name, true );
+      if( function_exists( 'get_field_object' ) ) {
+        $field_object = get_field_object( $field_name, $object['id'] );
+        if( 'wysiwyg' === $field_object['type'] ) {
+          return apply_filters( 'the_content', get_post_meta( $object[ 'id' ], $field_name, true ) );
+        }
+      }
+      return get_post_meta( $object[ 'id' ], $field_name, true );
     }
 
     // /**

--- a/jacobin-core-functionality.php
+++ b/jacobin-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     jacobin-core
  * Domain Path:     /languages
  *
- * Version:         0.3.18
+ * Version:         0.3.19
  *
  * @package         Core_Functionality
  */
@@ -54,7 +54,7 @@ require_once( 'admin/class-jacobin-core-admin.php' );
  * @return object Jacobin_Core
  */
 function Jacobin_Core () {
-	$instance = Jacobin_Core::instance( __FILE__, '0.3.18' );
+	$instance = Jacobin_Core::instance( __FILE__, '0.3.19' );
 
 	return $instance;
 }
@@ -116,4 +116,18 @@ Jacobin_Core()->register_taxonomy(
     __( 'Series', 'jacobin-core' ),
     __( 'Series', 'jacobin-core' ),
     'post'
+);
+
+/**
+ * Register Internal Status Class
+ * @var [type]
+ */
+Jacobin_Core()->register_taxonomy(
+    'status-internal',
+    __( 'Statuses', 'jacobin-core' ),
+    __( 'Status', 'jacobin-core' ),
+    array(
+			'post',
+			'issue'
+		)
 );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: misfist
 Tags: custom post type, custom taxonomy, rest api
 Requires at least: 4.7
 Tested up to: 4.8.0
-Version: 0.3.18
+Version: 0.3.19
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,10 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 0.3.19 September 25f, 2017 =
+* #332 Added new status taxonomy for internal use.
+* #334 Added Autop for antescript and postscript. wysiwyg fields are now treated like `the_content`.
 
 = 0.3.18 Septembere 21, 2017 =
 * #326 Modified featured content (``/wp-json/jacobin/featured-content/{slug}/``) rendered title to use default filters


### PR DESCRIPTION
* #332 Added new status taxonomy for internal use.
* #334 Added Autop for antescript and postscript. wysiwyg fields are now treated like `the_content`.

https://github.com/positiondev/jacobin/issues/332
https://github.com/positiondev/jacobin/issues/334