### PR TITLE
Allowed editor role to view list of users

### DIFF
--- a/admin/class-jacobin-core-admin.php
+++ b/admin/class-jacobin-core-admin.php
@@ -89,8 +89,13 @@ class Jacobin_Core_Admin {
 		 */
 		add_filter( 'status-internal_register_args', array( $this, 'modify_status_taxonomy_args' ) );
 
-	}
+		/**
+		 * Modify Editor Role Capabilities
+		 * @since 0.4.1
+		 */
+		add_action( 'admin_init', array( $this, 'modify_editor_role_capabilities' ) );
 
+	}
 
 	/**
 	 * Add an Options Page using ACF
@@ -303,6 +308,21 @@ class Jacobin_Core_Admin {
 			remove_meta_box( 'categorydiv', 'post', 'side' );
 			remove_meta_box( 'tagsdiv-post_tag', 'post', 'side' );
 			remove_meta_box( 'locationdiv', 'post', 'side' );
+	}
+
+	/**
+	 * Modify Editor Role Capabilities
+	 * Allow the editor role to view users list
+	 *
+	 * @since 0.4.1
+	 *
+	 * @link https://codex.wordpress.org/Roles_and_Capabilities#Editor
+	 *
+	 * @return void
+	 */
+	function modify_editor_role_capabilities() {
+		$role = get_role( 'editor' );
+		$role->add_cap( 'list_users' );
 	}
 
 }

--- a/jacobin-core-functionality.php
+++ b/jacobin-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     jacobin-core
  * Domain Path:     /languages
  *
- * Version:         0.4.0
+ * Version:         0.4.1
  *
  * @package         Core_Functionality
  */
@@ -54,7 +54,7 @@ require_once( 'admin/class-jacobin-core-admin.php' );
  * @return object Jacobin_Core
  */
 function Jacobin_Core () {
-	$instance = Jacobin_Core::instance( __FILE__, '0.4.0' );
+	$instance = Jacobin_Core::instance( __FILE__, '0.4.1' );
 
 	return $instance;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: misfist
 Tags: custom post type, custom taxonomy, rest api
 Requires at least: 4.7
 Tested up to: 4.8.0
-Version: 0.4.0
+Version: 0.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 0.4.1 October 1, 2017 =
+* #336 Allowed editor role to view list of users (cap = `list_users`) so that they can manage guest authors @link https://github.com/positiondev/jacobin/issues/346
 
 = 0.4.0 October 1, 2017 =
 * #342 Changed content section structure @link https://github.com/positiondev/jacobin/issues/342


### PR DESCRIPTION
* #336 Allowed editor role to view list of users (cap = `list_users`) so that they can manage guest authors @link https://github.com/positiondev/jacobin/issues/346