### PR TITLE
6 Create special guest authors endpoint

### DIFF
--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -1359,7 +1359,7 @@
             ),
             'allow_null' => 0,
             'multiple' => 1,
-            'return_format' => 'id',
+            'return_format' => 'object',
             'ui' => 1,
           ),
           array (

--- a/includes/class-jacobin-core-register-fields.php
+++ b/includes/class-jacobin-core-register-fields.php
@@ -387,7 +387,7 @@ class Jacobin_Rest_API_Fields {
      *
      * @return {array} $data
      */
-     function modify_post_response_taxonomy ( $response, $post, $request ) {
+     function modify_post_response_taxonomy( $response, $post, $request ) {
          $_data = $response->data;
 
          $taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
@@ -444,7 +444,7 @@ class Jacobin_Rest_API_Fields {
      * @return string meta
      *
      */
-    public function get_field ( $object, $field_name, $request ) {
+    public function get_field( $object, $field_name, $request ) {
       if( function_exists( 'get_field_object' ) ) {
         $field_object = get_field_object( $field_name, $object['id'] );
         if( 'wysiwyg' === $field_object['type'] ) {
@@ -515,7 +515,7 @@ class Jacobin_Rest_API_Fields {
      * @param array $request
      * @return array image meta || false
      */
-    public function get_featured_image_secondary ( $object, $field_name, $request ) {
+    public function get_featured_image_secondary( $object, $field_name, $request ) {
         $image_id = get_post_meta( $object['id'], $field_name, true );
         return ( !empty( $image_id ) ) ? jacobin_get_image_meta( $image_id ) : false;
     }
@@ -587,7 +587,7 @@ class Jacobin_Rest_API_Fields {
      * @return {array} $articles
      *
      */
-    public function get_issue_articles ( $object, $field_name, $request ) {
+    public function get_issue_articles( $object, $field_name, $request ) {
         $meta = get_post_meta( $object['id'], 'article_issue_relationship', true );
         $articles = [];
 
@@ -626,7 +626,7 @@ class Jacobin_Rest_API_Fields {
      * @return {array} $articles
      *
      */
-    public function get_related_articles ( $object, $field_name, $request ) {
+    public function get_related_articles( $object, $field_name, $request ) {
         $meta = get_post_meta( $object['id'], 'related_articles', true );
         $articles = [];
 
@@ -659,7 +659,7 @@ class Jacobin_Rest_API_Fields {
      * @return {array} $authors
      *
      */
-    public function get_authors ( $object, $field_name, $request ) {
+    public function get_authors( $object, $field_name, $request ) {
         return jacobin_get_authors_array( $object['id'] );
     }
 

--- a/includes/class-jacobin-core-shortcodes.php
+++ b/includes/class-jacobin-core-shortcodes.php
@@ -24,7 +24,7 @@ class Jacobin_Register_Shortcodes {
      */
     function __construct() {
 
-        add_action( 'init', array( $this, 'detect_shortcode_ui' ) );
+        // add_action( 'init', array( $this, 'detect_shortcode_ui' ) );
         add_action( 'init', array( $this, 'register_shortcodes' ) );
         add_action( 'init', array( $this, 'register_shortcode_ui' ) );
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -195,7 +195,7 @@ function jacobin_featured_images_get_field( $image_id ) {
  *
  * @return array $meta || false
  */
-function jacobin_get_coauthor_meta( $author_id  ) {
+function jacobin_get_coauthor_meta( $author_id ) {
 
     $user_id = (int) $author_id;
 
@@ -205,6 +205,7 @@ function jacobin_get_coauthor_meta( $author_id  ) {
         'id'            => $user_id,
         'slug'          => get_post_meta( $user_id, 'cap-user_login', true ),
         'name'          => get_post_meta( $user_id, 'cap-display_name', true ),
+        'display_name'  => get_post_meta( $user_id, 'cap-display_name', true ),
         'first_name'    => get_post_meta( $user_id, 'cap-first_name', true ),
         'last_name'     => get_post_meta( $user_id, 'cap-last_name', true ),
         'nickname'      => get_post_meta( $user_id, 'cap-nickname', true ),
@@ -285,6 +286,7 @@ function jacobin_get_author_meta( $author_id ) {
     $meta = array(
         'id'            => $author_id,
         'name'          => $user_meta->display_name,
+        'display_name'  => $user_meta->display_name,
         'first_name'    => $user_meta->first_name,
         'last_name'     => $user_meta->last_name,
         'description'   => $user_meta->description,


### PR DESCRIPTION
v 0.5.12
- Register route
- Add callback to fetch data

data will be returned in the form:

```json
{
   'author name': [ 
      'author', 
      'interviewer', 
      'translator'
   ],
   'author name': [ 
      'interviewer', 
   ],
   'author name': [ 
      'translator'
   ],
}
```
Add `display_name` property for consistency
Clean up method formatting
Return translator `object` instead of `id`
Suppress Shortcode alert message