### PR TITLE
Pea/GitHub actions

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -1,0 +1,22 @@
+name: deploy-live
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: unnecessary
+
+      - name: Adding Known Hosts
+        run: ssh-keyscan -H ${{ secrets.SSH_HOST }}  >> ~/.ssh/known_hosts
+
+      - name: Deploy with rsync
+        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/u2-pp808pfon9lg/www/remeikef1.sg-host.com/public_html/wp-content/plugins/jacobin-core-functionality

--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -19,4 +19,4 @@ jobs:
         run: ssh-keyscan -H ${{ secrets.SSH_HOST }}  >> ~/.ssh/known_hosts
 
       - name: Deploy with rsync
-        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/u2-pp808pfon9lg/www/remeikef1.sg-host.com/public_html/wp-content/plugins/jacobin-core-functionality
+        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/u2-pp808pfon9lg/www/editor.jacobin.com/public_html/wp-content/plugins/core-functionality

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -1,0 +1,22 @@
+name: deploy-stage
+on:
+  push:
+    branches:
+      - staging
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: unnecessary
+
+      - name: Adding Known Hosts
+        run: ssh-keyscan -H ${{ secrets.SSH_HOST }}  >> ~/.ssh/known_hosts
+
+      - name: Deploy with rsync
+        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/u2-pp808pfon9lg/www/remeikef1.sg-host.com/public_html/wp-content/plugins/jacobin-core-functionality

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -19,4 +19,4 @@ jobs:
         run: ssh-keyscan -H ${{ secrets.SSH_HOST }}  >> ~/.ssh/known_hosts
 
       - name: Deploy with rsync
-        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/u2-pp808pfon9lg/www/remeikef1.sg-host.com/public_html/wp-content/plugins/jacobin-core-functionality
+        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/u2-pp808pfon9lg/www/staging2.remeikef1.sg-host.com/public_html/wp-content/plugins/jacobin-core-functionality

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -19,4 +19,4 @@ jobs:
         run: ssh-keyscan -H ${{ secrets.SSH_HOST }}  >> ~/.ssh/known_hosts
 
       - name: Deploy with rsync
-        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/u2-pp808pfon9lg/www/staging2.remeikef1.sg-host.com/public_html/wp-content/plugins/jacobin-core-functionality
+        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/u2-pp808pfon9lg/www/staging.editor.jacobin.com/public_html/wp-content/plugins/core-functionality

--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -26,11 +26,17 @@
       */
      function __construct() {
 
-         if( function_exists( 'register_field_group' ) ) {
-           $this->register_clone_fields();
-           $this->register_field_groups();
-           $this->register_settings_fields();
-         }
+      /**
+       * Register Fields
+       * 
+       * @link https://www.advancedcustomfields.com/resources/register-fields-via-php/#add-within-an-action
+       * 
+       * 
+       * @since 0.5.21
+       */
+         add_action( 'acf/init', array( $this, 'register_clone_fields' ) );
+         add_action( 'acf/init', array( $this, 'register_field_groups' ) );
+         add_action( 'acf/init', array( $this, 'register_settings_fields' ) );
 
          add_filter( 'coauthors_guest_author_fields', array( $this, 'add_guest_author_fields' ), 10, 2 );
 

--- a/jacobin-core-functionality.php
+++ b/jacobin-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     jacobin-core
  * Domain Path:     /languages
  *
- * Version:         0.5.20.5
+ * Version:         0.5.21
  *
  * @package         Core_Functionality
  */
@@ -60,7 +60,7 @@ require_once( 'integrations/wp-cli.php' );
  * @return object Jacobin_Core
  */
 function Jacobin_Core () {
-	$instance = Jacobin_Core::instance( __FILE__, '0.5.20.5' );
+	$instance = Jacobin_Core::instance( __FILE__, '0.5.21' );
 
 	return $instance;
 }


### PR DESCRIPTION
- [Add github actions for deployment](https://github.com/jacobinmag/jacobin-core-functionality/commit/2994d9a897778f2cbc0e3c62c03af3ada7ffd12e)
- [Register ACF Fields within action](https://github.com/jacobinmag/jacobin-core-functionality/commit/c8615bcbc716402d49c1c8dffb537757aa20280d) 
   - https://www.advancedcustomfields.com/resources/register-fields-via-php/#add-within-an-action
- [Update github action workflows w new server paths](https://github.com/jacobinmag/jacobin-core-functionality/commit/7ce93291f741d4dfa682c545a65d2def9ad51b71)