### PR TITLE
Pea/fix legacy issues

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -9,10 +9,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Adding Known Hosts
-        run: 
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.SSH_HOST }}  >> ~/.ssh/known_hosts
-
-      - name: Deploy with rsync
-        run: rsync -avz --exclude={.*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/} --delete "ssh -p 18765" ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.WORK_DIR }}editor.jacobin.com/public_html/wp-content/plugins/core-functionality
+      - name: Deploy to Server
+        uses: easingthemes/ssh-deploy@main
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          ARGS: "-rlgoDzvc -i --delete"
+          SOURCE: "./"
+          REMOTE_HOST: ${{ secrets.SSH_HOST }}
+          REMOTE_USER: ${{ secrets.SSH_USER }}
+          REMOTE_PORT: "18765"
+          TARGET: ${{ secrets.WORK_DIR }}editor.jacobin.com/public_html/wp-content/plugins/core-functionality
+          EXCLUDE: ".*,*lock,*~,phpcs.xml.dist,postcss.config.js,webpack.*.js,.*/,node_modules/"

--- a/includes/class-jacobin-core-register-routes.php
+++ b/includes/class-jacobin-core-register-routes.php
@@ -67,6 +67,7 @@ class Jacobin_Rest_API_Routes {
 				  ),
 				  'required'    => true
 			  ),
+			  'permission_callback' => '__return_true',
 			),
 		) );
   
@@ -80,6 +81,7 @@ class Jacobin_Rest_API_Routes {
 					}
 				),
 			),
+			'permission_callback' => '__return_true',
 		) );
   
 		register_rest_route( $this->namespace, '/guest-author', array(
@@ -108,6 +110,7 @@ class Jacobin_Rest_API_Routes {
 					}
 				),
 			),
+			'permission_callback' => '__return_true',
 		) );
   
 		register_rest_route( $this->namespace, '/guest-author/(?P<id>\d+)', array(
@@ -120,6 +123,7 @@ class Jacobin_Rest_API_Routes {
 					}
 				),
 			),
+			'permission_callback' => '__return_true',
 		) );
 
 		register_rest_route( $this->namespace, '/featured-content/(?P<slug>[a-zA-Z0-9-]+)', array(
@@ -151,32 +155,35 @@ class Jacobin_Rest_API_Routes {
 						'validate_callback' => function( $param, $request, $key ) {
 							return ( is_numeric( $param ) );
 						}
-					),
+				),
 				'id' => array(
 					'description' => esc_html__( 'The guest author id parameter is used to retrieve a guest author', 'jacobin-core' ),
 					'type'        => 'number',
 						'validate_callback' => function( $param, $request, $key ) {
 							return ( is_numeric( $param ) && 'guest-author' == get_post_type( $param ) );
 						}
-					),
 				),
+			),
+			'permission_callback' => '__return_true',
 		) );
 
 		register_rest_route( $this->namespace, '/guest-author/(?P<id>\d+)', array(
 			'methods'     => 'GET',
 			'callback'    => array( $this, 'get_guest_author' ),
 			'args' => array(
-					'term_id' => array(
-						'validate_callback' => function( $param, $request, $key ) {
-							return ( is_numeric( $param ) );
-						}
-					),
+				'term_id' => array(
+					'validate_callback' => function( $param, $request, $key ) {
+						return ( is_numeric( $param ) );
+					}
 				),
+			),
+			'permission_callback' => '__return_true',
 		) );
 	  
 		register_rest_route( $this->namespace, 'search', array(
 			'methods'  => WP_REST_Server::READABLE,
 			'callback' => array( $this, 'get_search' ),
+			'permission_callback' => '__return_true',
 		) );
 
 	  /**
@@ -188,13 +195,14 @@ class Jacobin_Rest_API_Routes {
 			'methods'     => 'GET',
 			'callback'    => array( $this, 'get_contributors' ),
 			'args' => array(
-					'id' => array(
-						'validate_callback' => function( $param, $request, $key ) {
-							return is_numeric( $param );
-				},
-				'required' => true
-					),
+				'id' => array(
+					'validate_callback' => function( $param, $request, $key ) {
+						return is_numeric( $param );
+			},
+			'required' => true
 				),
+			),
+			'permission_callback' => '__return_true',
 	  ) );
 
 	  /**
@@ -213,6 +221,7 @@ class Jacobin_Rest_API_Routes {
 					'required' => true
 				),
 			),
+			'permission_callback' => '__return_true',
 		));
 
 	}


### PR DESCRIPTION
- [Update deploy action](https://github.com/jacobinmag/jacobin-core-functionality/commit/7e0454e83a52b8a3d64e14c147d53874eb00330d)
- [Add permission_callback](https://github.com/jacobinmag/jacobin-core-functionality/commit/4c1393927f5d52d986a48a891bf5a55c1698db4e)
   - Fixes
   - `PHP Notice:  Function register_rest_route was called <strong>incorrectly</strong>. The REST API route definition for <code>jacobin/featured-content/(?P<slug>[a-zA-Z0-9-]+)</code> is missing the required <code>permission_callback</code> argument. For REST API routes that are intended to be public, use <code>__return_true</code> as the permission callback. Please see <a href="[https://wordpress.org/documentation/article/debugging-in-wordpress/">Debugging](https://wordpress.org/documentation/article/debugging-in-wordpress/%22%3EDebugging) in WordPress</a> for more information. (This message was added in version 5.5.0.)`
