### PR TITLE
Pea/bugfix footnotes saving

### DIFF
--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -1330,7 +1330,6 @@
       			'label' => __( 'Footnotes', 'jacobin-core' ),
       			'name' => 'footnotes',
       			'type' => 'wysiwyg',
-      			'value' => NULL,
       			'instructions' => '',
       			'required' => 0,
       			'conditional_logic' => 0,


### PR DESCRIPTION
- [Bugfix - Footnotes saving](https://github.com/jacobinmag/jacobin-core-functionality/commit/2de7f9e7acd00acb4927e70fac23be6ea3379754)
   - Reported some editors unable to save footnotes field value
   - Remove `'value' => NULL`