### PR TITLE
Pea/35 footnotes saving issue

### DIFF
--- a/includes/class-jacobin-core-custom-fields.php
+++ b/includes/class-jacobin-core-custom-fields.php
@@ -1328,7 +1328,7 @@
           array (
       			'key' => 'field_footnotes',
       			'label' => __( 'Footnotes', 'jacobin-core' ),
-      			'name' => 'footnotes',
+      			'name' => 'endnotes',
       			'type' => 'wysiwyg',
       			'instructions' => '',
       			'required' => 0,

--- a/includes/class-jacobin-core-register-fields.php
+++ b/includes/class-jacobin-core-register-fields.php
@@ -110,7 +110,7 @@ class Jacobin_Rest_API_Fields {
 				array( 'post', 'revision' ),
 				'footnotes',
 				array(
-					'get_callback'    => array( $this, 'get_field' ),
+					'get_callback'    => array( $this, 'get_footnotes' ),
 					'update_callback' => null,
 					'schema'          => null,
 				)
@@ -563,6 +563,20 @@ class Jacobin_Rest_API_Fields {
 			}
 		}
 		return get_post_meta( $object['id'], $field_name, true );
+	}
+
+	/**
+	 * Get footnotes
+	 * Field name is `endnotes` by property in REST response is `footnotes`
+	 *
+	 * @since 0.5.25
+	 *
+	 * @param object $object
+	 * @param string $request
+	 * @return string meta
+	 */
+	public function get_footnotes( $object, $request ) {
+		return get_post_meta( $object['id'], 'endnotes', true );
 	}
 
 	/**

--- a/integrations/class-copy-post-meta.php
+++ b/integrations/class-copy-post-meta.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Jacobin Core User Utilities
+ *
+ * @package    Jacobin_Core
+ * @since      0.5.25
+ * @license    GPL-2.0+
+ */
+
+namespace Jacobin_Core;
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	return;
+}
+
+/**
+ * Copy Post Meta Multisite Command class.
+ */
+class Copy_Meta {
+
+	/**
+	 * Copy post meta from one field to another for each site in a WordPress multisite instance.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <old_field>
+	 * : The name of the old post meta field.
+	 *
+	 * <new_field>
+	 * : The name of the new post meta field.
+	 *
+	 * [--dry-run]
+	 * : Execute a dry run without updating the database.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp jacobin copy-meta copy_meta_field new_meta_field
+	 *     wp jacobin copy-meta copy_meta_field new_meta_field --dry-run
+	 *
+	 * @param array $args       Command arguments.
+	 * @param array $assoc_args Command associative arguments.
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		list( $old_field, $new_field ) = $args;
+
+		$dry_run = isset( $assoc_args['dry-run'] );
+
+		\WP_CLI::line( "Copying post meta from '{$old_field}' to '{$new_field}' for each site..." );
+
+		$sites = get_sites();
+
+		foreach ( $sites as $site ) {
+			\switch_to_blog( $site->blog_id );
+
+			$posts = \get_posts(
+				array(
+					'post_type'      => 'post',
+					'posts_per_page' => -1,
+				)
+			);
+
+			foreach ( $posts as $post ) {
+				$old_value = \get_post_meta( $post->ID, $old_field, true );
+
+				if ( $dry_run ) {
+					\WP_CLI::line( "Dry run: Site {$site->blog_id}, Post {$post->ID} - Old Value: {$old_value}" );
+				} else {
+					\update_post_meta( $post->ID, $new_field, $old_value );
+					\WP_CLI::line( "Site {$site->blog_id}, Post {$post->ID} - Copied '{$old_field}' to '{$new_field}'" );
+				}
+			}
+
+			\restore_current_blog();
+		}
+
+		\WP_CLI::success( 'Multisite post meta copy complete.' );
+	}
+}
+
+// Register the command when WP_CLI is ready.
+\WP_CLI::add_command( 'jacobin copy-meta', __NAMESPACE__ . '\Copy_Meta' );

--- a/jacobin-core-functionality.php
+++ b/jacobin-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     jacobin-core
  * Domain Path:     /languages
  *
- * Version:         0.5.24
+ * Version:         0.5.25
  *
  * @package         Core_Functionality
  */
@@ -63,7 +63,7 @@ require_once 'integrations/class-copy-post-meta.php';
  * @return object Jacobin_Core
  */
 function Jacobin_Core() {
-	$instance = Jacobin_Core::instance( __FILE__, '0.5.24' );
+	$instance = Jacobin_Core::instance( __FILE__, '0.5.25' );
 
 	return $instance;
 }

--- a/jacobin-core-functionality.php
+++ b/jacobin-core-functionality.php
@@ -52,6 +52,7 @@ require_once 'utils/media-utilities.php';
 require_once 'utils/user-utilities.php';
 require_once 'utils/revision-management.php';
 require_once 'integrations/wp-cli.php';
+require_once 'integrations/class-copy-post-meta.php';
 
 
 


### PR DESCRIPTION
Addresses postmeta field naming issue. Since WordPress 6.4, there is a core footnotes block, which uses a postmeta field named `footnotes` . So, our old `footnotes` field isn’t being saved because WP is expecting the data to come from the footnotes block.

Solution:
Copy the contents of existing `footnotes` postmeta to a new field called `endnotes` . Rename the ACF `footnotes` custom field `endnotes`. Preserve the REST property name `footnotes` to avoid frontend issues.

- [Add WP-CLI command to copy contents of `footnotes` to `endnotes`](https://github.com/jacobinmag/jacobin-core-functionality/commit/a9d78e7ff0034b814bb123ced1a6d9bedb0e7b38)
- [Change ACF fieldname from `footnotes` to `endnotes`](https://github.com/jacobinmag/jacobin-core-functionality/commit/ec7de21977c6ae7a32c523e8811bad8557d98e18)
- [Change REST field to get new `endnotes` field data](https://github.com/jacobinmag/jacobin-core-functionality/commit/08b5a959e427e4f77ded5c8d53633ae0cf3e1f50)